### PR TITLE
fix: remove unnecessary publish and redirects configuration from Netlify settings

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,5 @@
 [build]
   command = "npm run build"
-  publish = "dist"
-
-[[redirects]]
-  from = "/*"
-  to = "/.netlify/functions/ssr"
-  status = 200
 
 [build.environment]
   NODE_VERSION = "18"


### PR DESCRIPTION
This pull request makes a minor update to the Netlify configuration by removing the custom publish directory and redirect rules from `netlify.toml`. This simplifies the deployment settings and may affect how the site is served or routed.

- Netlify configuration simplification:
  * Removed the `publish` directory setting and the redirect rule that routed all requests to the `/.netlify/functions/ssr` serverless function in `netlify.toml`.