### PR TITLE
fix: adjust XP sorting and display for skills to improve accuracy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -156,7 +156,7 @@ const toISODateTime = (dateString: string | undefined): string | null => {
                   </thead>
                   <tbody>
                     {[...skills]
-                      .sort((a, b) => (b?.xp || 0) - (a?.xp || 0))
+                      .sort((a, b) => (b?.xp || 0) / 10 - (a?.xp || 0) / 10)
                       .map((skill) => (
                         <tr class="border-b border-gray-100 hover:bg-gray-50">
                           <td class="py-3 px-4 font-medium">
@@ -167,7 +167,7 @@ const toISODateTime = (dateString: string | undefined): string | null => {
                             {skill?.level || 0}
                           </td>
                           <td class="text-right py-3 px-4">
-                            {(skill?.xp || 0).toLocaleString()}
+                            {Math.floor((skill?.xp || 0) / 10).toLocaleString()}
                           </td>
                           <td class="text-right py-3 px-4">
                             {(skill?.rank || 0).toLocaleString()}


### PR DESCRIPTION
This pull request makes a minor adjustment to how skill experience (`xp`) is displayed and sorted on the main page. Experience values are now divided by 10 before sorting and display, which changes the granularity of the data shown to users.

- **Skill Experience Handling:**
  - Skill experience (`xp`) is now divided by 10 before sorting skills in the table, which may affect the order in which skills are displayed.
  - The displayed experience value for each skill is also divided by 10 and floored, so users will see a lower, rounded-down value in the UI.