### PR TITLE
feat: add id prop to Hero component and update DataLoader to use it for dynamic hero title

### DIFF
--- a/src/components/DataLoader.astro
+++ b/src/components/DataLoader.astro
@@ -42,7 +42,7 @@ const heroTitle = `${characterName}'s RuneScape Overview`;
 
   <div id="content-state" class="hidden">
     <Container>
-      <Hero headline={heroTitle} />
+      <Hero headline={heroTitle} id="hero-title" />
       <!-- Player Stats -->
       <Section id="player-stats-section">
         <Divider loading="eager" />
@@ -90,6 +90,13 @@ const heroTitle = `${characterName}'s RuneScape Overview`;
 
 <script define:vars={{ characterName, SKILL_NAMES }}>
   async function loadPlayerData() {
+    // Check if the data-loader component exists on this page
+    const dataLoaderElement = document.getElementById("data-loader");
+    if (!dataLoaderElement) {
+      // Component not on this page, exit silently
+      return;
+    }
+
     const loadingState = document.getElementById("loading-state");
     const contentState = document.getElementById("content-state");
     const errorState = document.getElementById("error-state");
@@ -119,7 +126,9 @@ const heroTitle = `${characterName}'s RuneScape Overview`;
       // Update Hero
       const heroTitle = document.getElementById("hero-title");
       if (heroTitle) {
-        heroTitle.textContent = data.name || characterName;
+        heroTitle.textContent = data.name
+          ? `${data.name}'s RuneScape Overview`
+          : `${characterName}'s RuneScape Overview`;
       } else {
         console.warn("Hero title element not found");
       }

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,9 +1,10 @@
 ---
 interface Props {
   headline: string;
+  id?: string;
 }
 
-const { headline } = Astro.props;
+const { headline, id } = Astro.props;
 ---
 
 <section class="relative overflow-hidden">
@@ -12,7 +13,10 @@ const { headline } = Astro.props;
   >
     {
       headline && (
-        <h1 class="text-4xl max-md:text-2xl font-cinzel font-bold uppercase text-yellow text-balance">
+        <h1
+          class="text-4xl max-md:text-2xl font-cinzel font-bold uppercase text-yellow text-balance"
+          id={id}
+        >
           {headline}
         </h1>
       )


### PR DESCRIPTION
This pull request improves the handling and updating of the hero title in the RuneScape Overview page, ensuring the displayed headline accurately reflects the player's name and that updates are made to the correct DOM element. The changes also add robustness to the data loading script by preventing errors on pages where the data loader component is not present.

**Hero Title Handling Improvements:**

* The `Hero` component now accepts an optional `id` prop, allowing the headline element to be uniquely identified for updates. (`src/components/Hero.astro`) [[1]](diffhunk://#diff-289237df7e7f2ebc1fa52e3aabba5f9a6599c1e53067fbf127b9d3a6b8943ab0R4-R7) [[2]](diffhunk://#diff-289237df7e7f2ebc1fa52e3aabba5f9a6599c1e53067fbf127b9d3a6b8943ab0L15-R19)
* The `DataLoader.astro` component passes `id="hero-title"` to the `Hero` headline, enabling targeted DOM updates. (`src/components/DataLoader.astro`)
* When updating the hero title in the script, the headline now consistently uses the format "`<name>'s RuneScape Overview`", falling back to the character name if none is available. (`src/components/DataLoader.astro`)

**Data Loader Robustness:**

* The data loader script now checks for the existence of the component before attempting DOM operations, preventing errors on pages where the component is absent. (`src/components/DataLoader.astro`)