### PR TITLE
feat: add fade-in animation to banner image for improved visual effect

### DIFF
--- a/src/components/Banner.astro
+++ b/src/components/Banner.astro
@@ -11,7 +11,7 @@ const { image = banner } = Astro.props;
 
 <div class="absolute inset-0 -z-1 w-full h-90">
   <Image
-    class="block w-full h-full object-cover object-center-right"
+    class="block w-full h-full object-cover object-center-right animate-[fadeIn_1.2s_ease-out]"
     src={image}
     alt=""
     loading="eager"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,11 @@
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
 @import "tailwindcss";
 
 /* Import variable Cinzel font - supports weights 400-900 in a single file */


### PR DESCRIPTION
This pull request introduces a fade-in animation to the banner image for a smoother visual effect. The changes involve adding a new keyframes animation and applying it to the banner image component.

**UI Enhancement:**

* Added a `fadeIn` keyframes animation in `global.css` to animate opacity from 0 to 1.
* Applied the `fadeIn` animation to the banner image by updating the `class` property in the `Banner.astro` component.