### PR TITLE
fix: update site URL in configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import netlify from "@astrojs/netlify";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://astro-runescape.netlify.app",
+  site: "https://runescape.proffer.dev/",
   output: "server",
   adapter: netlify(),
   integrations: [sitemap()],


### PR DESCRIPTION
This pull request updates the deployment configuration for the Astro site by changing the production site URL in the `astro.config.mjs` file.

- Deployment configuration:
  * Updated the `site` property in `astro.config.mjs` from `https://astro-runescape.netlify.app` to `https://runescape.proffer.dev/` to reflect the new production domain.